### PR TITLE
v1.1.0 — Homebridge v2 support with new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,82 +1,105 @@
-# homebridge-platform-linktap 
+# homebridge-platform-linktap-v2
 
-[![npm package](https://nodei.co/npm/homebridge-platform-linktap.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/homebridge-platform-linktap/)
+A maintained fork of the LinkTap Homebridge plugin, updated for **Homebridge v2** and modern HAP-nodejs, with security and reliability fixes.
 
-[![NPM Version](https://img.shields.io/npm/v/homebridge-platform-linktap.svg)](https://www.npmjs.com/package/homebridge-platform-linktap)
-[![Dependency Status](https://www.versioneye.com/user/projects/5a786fed0fb24f1f133fae07/badge.svg?style=flat-square)](https://www.versioneye.com/user/projects/5a786fed0fb24f1f133fae07)
-[![Slack Channel](https://img.shields.io/badge/slack-platform--linktap-brightgreen.svg)](https://homebridgeteam.slack.com/messages/C93QDKXSP/)
+> **Note:** This work is based on / forked from [hakt0-r/homebridge-platform-linktap](https://github.com/hakt0-r/homebridge-platform-linktap). All original functionality and credit belong to the original author; this fork builds on that codebase to add Homebridge v2 compatibility and related fixes.
 
+## Why this fork exists
 
-LinkTap Platform Plugin for the [Homebridge](https://github.com/nfarina/homebridge) project.
+The original plugin fails to start on Homebridge v2 with errors like:
 
-# Note - seriously WIP
-
-This package is currently being developed and is a WORK IN PROGRESS. Its currently in the ALPHA stage. 
-
-## LinkTap
-
-[LinkTap] (https://www.link-tap.com) is a wireless tap that is controlled by the LinkTap's wireless bridge.
-There is a published LinkTap [API](https://www.link-tap.com/#!/api-for-developers). 
-
-# Installation
-
-1. Install homebridge using: `npm install -g homebridge`
-2. Install this plugin using: `npm install -g homebridge-platform-linktap`
-3. Update your configuration file. See the sample below.
-
-# Updating
-
-npm update -g homebridge-platform-linktap
-
-# Configuration
-
-Configuration sample:
-
- ```javascript
-// this is an example please do not copy/paste.
-
-"platforms":[
-    {
-        "platform": "LinkTapPlatform",
-        "username": "test",				//Required. String type. Your LinkTap account's username
-        "apiKey": "a6f1223d1fe191f8ec55662d1eb45720'",	//Required. String type. Your API key
-        "gatewayId": "3F7A23FE004B1200",		//Required. String type. Your LinkTap Gateway's first 16-digits/letters ID, case insensitive, no dash symbol
-        "taps": [
-            {
-                "name": "lawn",				//Required. LinkTap name friendly name.
-                "location": "Front yard",		//Optional. friendly location name.
-                "taplinkerId": "67ABCDEF004B1200",	//Required. String type. Your LinkTap Taplinker's first 16-digits/letters ID, case insensitive, no dash symbol
-                "duration": 1				//Required. The watering duration (unit is minutes) 1..1439 minutes. Default 1 minute.
-           }
-	]
-    }
-]
+```
+TypeError: Class constructor Characteristic cannot be invoked without 'new'
+TypeError: Cannot read properties of undefined (reading 'INT')
 ```
 
-# Known Issues
+This fork resolves those, removes a deprecated dependency, and fixes several bugs. The same changes have been submitted upstream as a pull request; this fork exists so the fix can be installed without waiting on the original repo.
 
-These are currently no known issues.
+## Installation
 
-# Future updates
+### 1. Uninstall the old plugin (if installed)
 
-These are some of the planned future updates to this project
-- Async Timer - Cause when the API call fails, we can cancel the timer and triger the switch-off process.
-~~- Implicit OFF - currently the switch-OFF is a timer based switch-off without the actual API call to implicitly switch off the tap. I'd like when the user switches off via the HomeKit the system determines if there is time left on the watering duration and if so issue the API call to switch off the LinkTap.~~
+```bash
+npm uninstall -g homebridge-platform-linktap
+```
 
-## Down the road...
+### 2. Install this version from GitHub
 
-These can be implemented as and when the LinkTap APIs are implemented. Some (if not all) are event driven.
-- Characteristic.Active 
-- Characteristic.BatteryLevel
-- Characteristic.InUse
-- Characteristic.StatusLowBattery
+```bash
+npm install -g https://github.com/phbuilds/homebridge-platform-linktap-v2
+```
 
-# Credits
+Or, if installing into a standard Homebridge instance:
 
-Credit goes to
-- michaelfro for his work on [homebridge-delayed-switches](https://github.com/grover/homebridge-delayed-switches) that this is work is based on.
-- [NorthernMan54](https://github.com/NorthernMan54) for helping me out and getting me across the line. Cheers mate! 
+```bash
+npm install --prefix /var/lib/homebridge https://github.com/phbuilds/homebridge-platform-linktap-v2
+```
 
-# License
+## Configuration
 
-Published under the MIT License.
+Add the following to the `platforms` section of your Homebridge `config.json`:
+
+```json
+{
+  "platform": "LinkTapPlatform",
+  "username": "your_linktap_username",
+  "apiKey": "your_api_key",
+  "gatewayId": "your_gateway_id",
+  "taps": [
+    {
+      "name": "Garden Tap",
+      "location": "Back garden",
+      "taplinkerId": "your_taplinker_id",
+      "duration": 10,
+      "autoBack": true
+    }
+  ]
+}
+```
+
+### Config fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `username` | Yes | Your LinkTap account username |
+| `apiKey` | Yes | Your API key from https://www.link-tap.com/#!/api-for-developers |
+| `gatewayId` | Yes | Your gateway's first 16-digit ID (no dashes) |
+| `name` | Yes | Friendly name for the tap |
+| `location` | No | Friendly location label |
+| `taplinkerId` | Yes | Your taplinker's first 16-digit ID (no dashes) |
+| `duration` | Yes | Watering duration in minutes (1 to 1439) |
+| `autoBack` | No | Auto-revert to the previous mode after watering. Defaults to `true` |
+
+## Behaviour notes
+
+- **Turning off:** switching a tap off in HomeKit sends a real stop command to LinkTap (it no longer just clears a local timer).
+- **Rate limiting:** the LinkTap API enforces a minimum 15-second interval between calls. If you turn a tap off shortly after turning it on, the off command is automatically deferred until that window clears, and is cancelled if you turn the tap back on in the meantime.
+- **Auto-off:** with `autoBack` enabled, the LinkTap device stops watering on its own when the duration elapses; HomeKit state is updated to match.
+
+## Changelog
+
+### 1.3.0
+- Removed the deprecated `request` dependency in favour of Node's built-in `https` module
+- Pinned `debug` to `^4.3.4`; corrected `engines` to realistic minimums (Node 18+, Homebridge 1.6+)
+
+### 1.2.0
+- Added a real turn-off command with a 15-second API rate-limit guard
+
+### 1.1.0
+- Stopped logging the API key
+- Fixed `autoBack` so `false` is respected
+- Fixed a double-callback crash on network errors
+- Use the real `taplinkerId` as the device serial number
+- Added config validation for a missing `taps` array
+
+### 1.0.0
+- Homebridge v2 compatibility: ES6 `Characteristic` class and string-based characteristic props
+
+## Credits
+
+- Original plugin by [hakt0-r](https://github.com/hakt0-r/homebridge-platform-linktap)
+- Based on [homebridge-delayed-switches](https://github.com/grover/homebridge-delayed-switches) by grover
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -2,19 +2,20 @@
 
 A [Homebridge](https://homebridge.io) plugin for [LinkTap](https://www.link-tap.com) wireless water timers.
 
-> **Note:** This is a fork of [hakt0-r/homebridge-platform-linktap](https://github.com/hakt0-r/homebridge-platform-linktap). All original functionality and credit belong to the original author; this work builds on that codebase to add Homebridge v2 compatibility, device status, alerts, and schedule pause.
+> **Note:** This is a fork of [hakt0-r/homebridge-platform-linktap](https://github.com/hakt0-r/homebridge-platform-linktap). All original functionality and credit belong to the original author; this work builds on that codebase to add Homebridge v2 compatibility, live status, alerts, flow metering, and schedule pause.
 
-Each tap appears in HomeKit as an irrigation valve, with battery level, connection status, watering state, fault alerts, and schedule pause/resume.
+Each tap appears in HomeKit as an irrigation valve, with battery level, connection status, watering state, fault alerts, water volume (G2/G2S), and schedule pause/resume.
 
 ## Features
 
-- Start/stop watering (instant mode) with a configurable duration
+- Start/stop watering (instant mode) with an adjustable duration
 - Real stop command on turn-off, with handling for the API's 15-second rate limit
 - Battery level and low-battery warning
 - Connection status (online/offline)
 - Live watering state (reflects watering started from the app, manual button, or schedules)
-- Combined fault alert (water cut, clog, fallen device, valve failure)
-- Pause and resume scheduled watering plans
+- Combined fault alert (water cut, clog, valve failure, fallen device, abnormal flow, freeze)
+- Water volume per cycle for G2/G2S flow-meter models (visible in Eve / Controller for HomeKit)
+- Pause and resume scheduled watering plans, with automatic detection of the active mode
 
 ## Installation
 
@@ -65,14 +66,15 @@ Add the following to the `platforms` section of your Homebridge `config.json`, o
 | `taplinkerId` | Yes | Your taplinker's first 16-digit ID (no dashes) |
 | `duration` | Yes | Watering duration in minutes (1 to 1439) |
 | `autoBack` | No | Auto-revert to the previous mode after watering. Default true |
-| `pauseHours` | No | How long the pause switch pauses scheduled watering (1 to 240, or -1 for indefinite). Default 24 |
+| `pauseHours` | No | How long the 'Pause Schedule' switch pauses scheduled watering (1 to 240, or -1 for indefinite). Default 24 |
 | `scheduleMode` | No | Watering plan type used to resume the schedule: `sevenDay`, `interval`, `oddEven`, `month`, or `calendar`. Default `sevenDay` |
 
 ## Notes
 
-- The LinkTap API rate-limits control calls to one per 15 seconds and status polling to once per 5 minutes, so status (battery, signal, watering, alerts) can take a few minutes to update.
+- The LinkTap API rate-limits control calls to one per 15 seconds and status polling to once per 5 minutes, so status (battery, signal, watering, alerts, volume) can take a few minutes to update.
 - Resume re-activates the watering plan that is live at the moment of resume, since the API has no standalone "resume" call.
 - Pause state and mode changes made in the LinkTap app are not currently reflected back in HomeKit, as the device status response does not include a pause-state field.
+- The tap is modelled as a valve service. If upgrading from a switch-based version, remove and re-add the accessory in the Home app once.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A [Homebridge](https://homebridge.io) plugin for [LinkTap](https://www.link-tap.
 
 > **Note:** This is a fork of [hakt0-r/homebridge-platform-linktap](https://github.com/hakt0-r/homebridge-platform-linktap). All original functionality and credit belong to the original author; this work builds on that codebase to add Homebridge v2 compatibility, live status, alerts, flow metering, and schedule pause.
 
-Each tap appears in HomeKit as an irrigation valve, with battery level, connection status, watering state, fault alerts, water volume (G2/G2S), and schedule pause/resume.
+Each tap appears in HomeKit as an irrigation valve (or a plain switch if preferred), with battery level, connection status, watering state, fault alerts, water volume (G2/G2S), and schedule pause/resume.
 
 ## Features
 
@@ -16,6 +16,7 @@ Each tap appears in HomeKit as an irrigation valve, with battery level, connecti
 - Combined fault alert (water cut, clog, valve failure, fallen device, abnormal flow, freeze)
 - Water volume per cycle for G2/G2S flow-meter models (visible in Eve / Controller for HomeKit)
 - Pause and resume scheduled watering plans, with automatic detection of the active mode
+- Choice of accessory type: irrigation valve (default) or legacy on/off switch
 
 ## Installation
 
@@ -41,6 +42,7 @@ Add the following to the `platforms` section of your Homebridge `config.json`, o
       "taplinkerId": "your_taplinker_id",
       "duration": 10,
       "autoBack": true,
+      "useValve": true,
       "pauseHours": 24,
       "scheduleMode": "sevenDay"
     }
@@ -66,6 +68,7 @@ Add the following to the `platforms` section of your Homebridge `config.json`, o
 | `taplinkerId` | Yes | Your taplinker's first 16-digit ID (no dashes) |
 | `duration` | Yes | Watering duration in minutes (1 to 1439) |
 | `autoBack` | No | Auto-revert to the previous mode after watering. Default true |
+| `useValve` | No | Expose the tap as an irrigation valve (adds Active/InUse and flow sensing). Set false for a legacy on/off switch. Default true |
 | `pauseHours` | No | How long the 'Pause Schedule' switch pauses scheduled watering (1 to 240, or -1 for indefinite). Default 24 |
 | `scheduleMode` | No | Watering plan type used to resume the schedule: `sevenDay`, `interval`, `oddEven`, `month`, or `calendar`. Default `sevenDay` |
 
@@ -74,7 +77,7 @@ Add the following to the `platforms` section of your Homebridge `config.json`, o
 - The LinkTap API rate-limits control calls to one per 15 seconds and status polling to once per 5 minutes, so status (battery, signal, watering, alerts, volume) can take a few minutes to update.
 - Resume re-activates the watering plan that is live at the moment of resume, since the API has no standalone "resume" call.
 - Pause state and mode changes made in the LinkTap app are not currently reflected back in HomeKit, as the device status response does not include a pause-state field.
-- The tap is modelled as a valve service. If upgrading from a switch-based version, remove and re-add the accessory in the Home app once.
+- The default valve model adds live flow sensing. If you switch between valve and switch (the `useValve` option), remove and re-add the accessory in the Home app once.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -1,43 +1,30 @@
-# homebridge-platform-linktap-v2
+# homebridge-platform-linktap
 
-A maintained fork of the LinkTap Homebridge plugin, updated for **Homebridge v2** and modern HAP-nodejs, with security and reliability fixes.
+A [Homebridge](https://homebridge.io) plugin for [LinkTap](https://www.link-tap.com) wireless water timers.
 
-> **Note:** This work is based on / forked from [hakt0-r/homebridge-platform-linktap](https://github.com/hakt0-r/homebridge-platform-linktap). All original functionality and credit belong to the original author; this fork builds on that codebase to add Homebridge v2 compatibility and related fixes.
+> **Note:** This is a fork of [hakt0-r/homebridge-platform-linktap](https://github.com/hakt0-r/homebridge-platform-linktap). All original functionality and credit belong to the original author; this work builds on that codebase to add Homebridge v2 compatibility, device status, alerts, and schedule pause.
 
-## Why this fork exists
+Each tap appears in HomeKit as an irrigation valve, with battery level, connection status, watering state, fault alerts, and schedule pause/resume.
 
-The original plugin fails to start on Homebridge v2 with errors like:
+## Features
 
-```
-TypeError: Class constructor Characteristic cannot be invoked without 'new'
-TypeError: Cannot read properties of undefined (reading 'INT')
-```
-
-This fork resolves those, removes a deprecated dependency, and fixes several bugs. The same changes have been submitted upstream as a pull request; this fork exists so the fix can be installed without waiting on the original repo.
+- Start/stop watering (instant mode) with a configurable duration
+- Real stop command on turn-off, with handling for the API's 15-second rate limit
+- Battery level and low-battery warning
+- Connection status (online/offline)
+- Live watering state (reflects watering started from the app, manual button, or schedules)
+- Combined fault alert (water cut, clog, fallen device, valve failure)
+- Pause and resume scheduled watering plans
 
 ## Installation
 
-### 1. Uninstall the old plugin (if installed)
-
 ```bash
-npm uninstall -g homebridge-platform-linktap
-```
-
-### 2. Install this version from GitHub
-
-```bash
-npm install -g https://github.com/phbuilds/homebridge-platform-linktap-v2
-```
-
-Or, if installing into a standard Homebridge instance:
-
-```bash
-npm install --prefix /var/lib/homebridge https://github.com/phbuilds/homebridge-platform-linktap-v2
+npm install -g homebridge-platform-linktap
 ```
 
 ## Configuration
 
-Add the following to the `platforms` section of your Homebridge `config.json`:
+Add the following to the `platforms` section of your Homebridge `config.json`, or use the Homebridge UI settings form:
 
 ```json
 {
@@ -45,61 +32,54 @@ Add the following to the `platforms` section of your Homebridge `config.json`:
   "username": "your_linktap_username",
   "apiKey": "your_api_key",
   "gatewayId": "your_gateway_id",
+  "pollInterval": 5,
   "taps": [
     {
       "name": "Garden Tap",
       "location": "Back garden",
       "taplinkerId": "your_taplinker_id",
       "duration": 10,
-      "autoBack": true
+      "autoBack": true,
+      "pauseHours": 24,
+      "scheduleMode": "sevenDay"
     }
   ]
 }
 ```
 
-### Config fields
+### Platform fields
 
 | Field | Required | Description |
 |-------|----------|-------------|
 | `username` | Yes | Your LinkTap account username |
 | `apiKey` | Yes | Your API key from https://www.link-tap.com/#!/api-for-developers |
 | `gatewayId` | Yes | Your gateway's first 16-digit ID (no dashes) |
-| `name` | Yes | Friendly name for the tap |
-| `location` | No | Friendly location label |
+| `pollInterval` | No | Status refresh in minutes. Minimum 5 (API limit). 0 disables polling. Default 5 |
+
+### Tap fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Friendly name shown in HomeKit |
+| `location` | No | Optional location label |
 | `taplinkerId` | Yes | Your taplinker's first 16-digit ID (no dashes) |
 | `duration` | Yes | Watering duration in minutes (1 to 1439) |
-| `autoBack` | No | Auto-revert to the previous mode after watering. Defaults to `true` |
+| `autoBack` | No | Auto-revert to the previous mode after watering. Default true |
+| `pauseHours` | No | How long the pause switch pauses scheduled watering (1 to 240, or -1 for indefinite). Default 24 |
+| `scheduleMode` | No | Watering plan type used to resume the schedule: `sevenDay`, `interval`, `oddEven`, `month`, or `calendar`. Default `sevenDay` |
 
-## Behaviour notes
+## Notes
 
-- **Turning off:** switching a tap off in HomeKit sends a real stop command to LinkTap (it no longer just clears a local timer).
-- **Rate limiting:** the LinkTap API enforces a minimum 15-second interval between calls. If you turn a tap off shortly after turning it on, the off command is automatically deferred until that window clears, and is cancelled if you turn the tap back on in the meantime.
-- **Auto-off:** with `autoBack` enabled, the LinkTap device stops watering on its own when the duration elapses; HomeKit state is updated to match.
-
-## Changelog
-
-### 1.3.0
-- Removed the deprecated `request` dependency in favour of Node's built-in `https` module
-- Pinned `debug` to `^4.3.4`; corrected `engines` to realistic minimums (Node 18+, Homebridge 1.6+)
-
-### 1.2.0
-- Added a real turn-off command with a 15-second API rate-limit guard
-
-### 1.1.0
-- Stopped logging the API key
-- Fixed `autoBack` so `false` is respected
-- Fixed a double-callback crash on network errors
-- Use the real `taplinkerId` as the device serial number
-- Added config validation for a missing `taps` array
-
-### 1.0.0
-- Homebridge v2 compatibility: ES6 `Characteristic` class and string-based characteristic props
+- The LinkTap API rate-limits control calls to one per 15 seconds and status polling to once per 5 minutes, so status (battery, signal, watering, alerts) can take a few minutes to update.
+- Resume re-activates the watering plan that is live at the moment of resume, since the API has no standalone "resume" call.
+- Pause state and mode changes made in the LinkTap app are not currently reflected back in HomeKit, as the device status response does not include a pause-state field.
 
 ## Credits
 
-- Original plugin by [hakt0-r](https://github.com/hakt0-r/homebridge-platform-linktap)
-- Based on [homebridge-delayed-switches](https://github.com/grover/homebridge-delayed-switches) by grover
+Credit goes to
+- michaelfro for his work on [homebridge-delayed-switches](https://github.com/grover/homebridge-delayed-switches) that this is work is based on.
+- [NorthernMan54](https://github.com/NorthernMan54) for helping me out and getting me across the line. Cheers mate!
 
 ## License
 
-MIT
+Published under the MIT License.

--- a/config.schema.json
+++ b/config.schema.json
@@ -79,7 +79,7 @@
               "type": "integer",
               "required": false,
               "default": 24,
-              "description": "How long the 'Pause Schedule' switch pauses scheduled watering. Range 1 to 240. Use -1 to pause indefinitely (relies on the resume action to restore it)."
+              "description": "How long the 'Pause Schedule' switch pauses scheduled watering when turned on. Range 1 to 240. Use -1 to pause indefinitely until switched off."
             },
             "scheduleMode": {
               "title": "Schedule Mode",

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,103 @@
+{
+  "pluginAlias": "LinkTapPlatform",
+  "pluginType": "platform",
+  "singular": true,
+  "headerDisplay": "LinkTap wireless water timer plugin. Create an API key at https://www.link-tap.com/#!/api-for-developers.",
+  "footerDisplay": "For help, see the [project README](https://github.com/phbuilds/homebridge-platform-linktap-v2).",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "username": {
+        "title": "Username",
+        "type": "string",
+        "required": true,
+        "description": "Your LinkTap account username."
+      },
+      "apiKey": {
+        "title": "API Key",
+        "type": "string",
+        "required": true,
+        "description": "Your API key from the LinkTap developer portal."
+      },
+      "gatewayId": {
+        "title": "Gateway ID",
+        "type": "string",
+        "required": true,
+        "description": "Your gateway's first 16-digit ID (no dashes), e.g. 3F7A23FE004B1200."
+      },
+      "pollInterval": {
+        "title": "Status Poll Interval (minutes)",
+        "type": "integer",
+        "required": false,
+        "default": 5,
+        "minimum": 0,
+        "description": "How often to refresh battery and signal status. Minimum 5 (LinkTap API limit). Set to 0 to disable status polling."
+      },
+      "taps": {
+        "title": "Taps",
+        "type": "array",
+        "required": true,
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "title": "Name",
+              "type": "string",
+              "required": true,
+              "description": "Friendly name shown in HomeKit."
+            },
+            "location": {
+              "title": "Location",
+              "type": "string",
+              "required": false,
+              "description": "Optional location label."
+            },
+            "taplinkerId": {
+              "title": "TapLinker ID",
+              "type": "string",
+              "required": true,
+              "description": "Your taplinker's first 16-digit ID (no dashes), e.g. 67ABCDEF004B1200."
+            },
+            "duration": {
+              "title": "Watering Duration (minutes)",
+              "type": "integer",
+              "required": true,
+              "default": 5,
+              "minimum": 1,
+              "maximum": 1439,
+              "description": "How long watering runs, 1 to 1439 minutes."
+            },
+            "autoBack": {
+              "title": "Auto-revert after watering",
+              "type": "boolean",
+              "required": false,
+              "default": true,
+              "description": "Return to the previous watering mode after the duration ends."
+            },
+            "pauseHours": {
+              "title": "Schedule Pause Duration (hours)",
+              "type": "integer",
+              "required": false,
+              "default": 24,
+              "description": "How long the 'Pause Schedule' switch pauses scheduled watering. Range 1 to 240. Use -1 to pause indefinitely (relies on the resume action to restore it)."
+            },
+            "scheduleMode": {
+              "title": "Schedule Mode",
+              "type": "string",
+              "required": false,
+              "default": "sevenDay",
+              "oneOf": [
+                { "title": "Seven Day", "enum": ["sevenDay"] },
+                { "title": "Interval", "enum": ["interval"] },
+                { "title": "Odd-Even", "enum": ["oddEven"] },
+                { "title": "Month", "enum": ["month"] },
+                { "title": "Calendar", "enum": ["calendar"] }
+              ],
+              "description": "The watering plan mode set up in the LinkTap app. Used to re-activate (resume) the schedule when the Pause switch is turned off."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/config.schema.json
+++ b/config.schema.json
@@ -74,6 +74,13 @@
               "default": true,
               "description": "Return to the previous watering mode after the duration ends."
             },
+            "useValve": {
+              "title": "Use irrigation valve",
+              "type": "boolean",
+              "required": false,
+              "default": true,
+              "description": "Expose the tap as a HomeKit irrigation valve (recommended; adds Active/InUse and live flow sensing). Set to false to use a plain on/off switch (legacy). Changing this requires re-adding the accessory in the Home app."
+            },
             "pauseHours": {
               "title": "Schedule Pause Duration (hours)",
               "type": "integer",

--- a/config.schema.json
+++ b/config.schema.json
@@ -3,7 +3,7 @@
   "pluginType": "platform",
   "singular": true,
   "headerDisplay": "LinkTap wireless water timer plugin. Create an API key at https://www.link-tap.com/#!/api-for-developers.",
-  "footerDisplay": "For help, see the [project README](https://github.com/phbuilds/homebridge-platform-linktap-v2).",
+  "footerDisplay": "For help, see the [project README](https://github.com/hakt0-r/homebridge-platform-linktap).",
   "schema": {
     "type": "object",
     "properties": {

--- a/index.js
+++ b/index.js
@@ -130,14 +130,6 @@ LinkTapPlatform.prototype._pollStatus = function() {
 // slightly by firmware, so matching and parsing here are deliberately defensive.
 LinkTapPlatform.prototype._applyStatus = function(parsed) {
   var that = this;
-
-  // TEMPORARY (v1.9.1): log the raw response at normal level so the device's
-  // field names (workMode, pause state, alerts) can be confirmed without the
-  // debug env var, which child-bridge processes don't always inherit.
-  try {
-    this.log("RAW getAllDevices: %s", JSON.stringify(parsed));
-  } catch (e) {}
-
   var gateways = parsed.devices || parsed.deviceList || [];
   var taplinkers = [];
 
@@ -192,19 +184,7 @@ LinkTapPlatform.prototype._applyStatus = function(parsed) {
       if (!fault && Array.isArray(d.alerts) && d.alerts.length > 0) fault = true;
     }
 
-    // Pause state, so the Home app reflects pause/resume done in the LinkTap app.
-    // Field name is unconfirmed across firmware; check the likely candidates and
-    // leave undefined (no override) when none are present.
-    var paused;
-    if (d.watactivated !== undefined) {        // some firmwares: watactivated=false when paused
-      paused = (d.watactivated === false);
-    } else if (d.paused !== undefined) {
-      paused = (d.paused === true || d.paused === 1);
-    } else if (d.pause !== undefined) {
-      paused = (d.pause === true || d.pause === 1 || (typeof d.pause === 'object' && d.pause !== null));
-    }
-
-    accessory.updateStatus(battery, signal, online, watering, fault, paused);
+    accessory.updateStatus(battery, signal, online, watering, fault);
   });
 };
 
@@ -341,7 +321,7 @@ LinkTapAccessory.prototype.getBatteryService = function() {
 };
 
 // Called by the platform poll loop with the latest status for this tap
-LinkTapAccessory.prototype.updateStatus = function(batteryPct, signalPct, online, watering, fault, paused) {
+LinkTapAccessory.prototype.updateStatus = function(batteryPct, signalPct, online, watering, fault) {
   if (batteryPct !== null && batteryPct !== undefined) {
     this._batteryLevel = batteryPct;
     this._statusLowBattery = batteryPct <= LOW_BATTERY_THRESHOLD ? 1 : 0;
@@ -385,17 +365,6 @@ LinkTapAccessory.prototype.updateStatus = function(batteryPct, signalPct, online
       this._faultService.updateCharacteristic(Characteristic.LeakDetected, this._fault);
     }
     if (this._fault) this.log.warn("%s reported an alert/fault condition", this.name);
-  }
-
-  // Reflect pause/resume performed outside HomeKit (e.g. in the LinkTap app)
-  if (paused !== null && paused !== undefined) {
-    var newPaused = paused ? 1 : 0;
-    if (newPaused !== this._paused) {
-      this._paused = newPaused;
-      if (this._pauseService) {
-        this._pauseService.updateCharacteristic(Characteristic.On, this._paused === 1);
-      }
-    }
   }
 
   this.log("%s status: battery %s%%, signal %s%%, %s%s%s",

--- a/index.js
+++ b/index.js
@@ -1,10 +1,21 @@
 const https = require('https');
 const _baseURL = 'https://www.link-tap.com/api/';
-const RATE_LIMIT_MS = 15000; // LinkTap API enforces a minimum 15s interval between calls
+const RATE_LIMIT_MS = 15000;        // activateInstantMode: min 15s between calls
+const MIN_POLL_MINUTES = 5;         // getAllDevices: manufacturer limits status polling to every 5 min
+const DEFAULT_POLL_MINUTES = 5;
+const LOW_BATTERY_THRESHOLD = 20;   // percent at or below which HomeKit shows a low-battery warning
 var Service, Characteristic, Accessory, UUIDGen;
 var debug = require('debug')('linktap');
 
 var username, apiKey, gatewayId;
+
+// Parse a battery/signal value that may arrive as a number (85) or a string ("85%")
+function parsePercent(val) {
+  if (val === null || val === undefined) return null;
+  if (typeof val === 'number') return Math.max(0, Math.min(100, Math.round(val)));
+  var m = String(val).match(/(\d+(\.\d+)?)/);
+  return m ? Math.max(0, Math.min(100, Math.round(parseFloat(m[1])))) : null;
+}
 
 module.exports = function(homebridge) {
   Service = homebridge.hap.Service;
@@ -12,7 +23,7 @@ module.exports = function(homebridge) {
   Accessory = homebridge.hap.Accessory;
   UUIDGen = homebridge.hap.uuid;
 
-  homebridge.registerPlatform("homebridge-platform-linktap", "LinkTapPlatform", LinkTapPlatform);
+  homebridge.registerPlatform("homebridge-platform-linktap-v2", "LinkTapPlatform", LinkTapPlatform);
 };
 
 function LinkTapPlatform(log, config, api) {
@@ -35,19 +46,166 @@ function LinkTapPlatform(log, config, api) {
 
 LinkTapPlatform.prototype.accessories = function(callback) {
   var that = this;
-  that.accessories = [];
+  that.accessoryList = [];
 
   if (!that.config.taps || !Array.isArray(that.config.taps)) {
     that.log.warn("No 'taps' array found in config - check your LinkTap configuration");
-    callback(that.accessories);
+    callback(that.accessoryList);
     return;
   }
 
   //tap is a config for each of the linktaps.
   that.config.taps.forEach(function(tap) {
-    that.accessories.push(new LinkTapAccessory(that.log, tap));
+    that.accessoryList.push(new LinkTapAccessory(that.log, tap));
   });
-  callback(that.accessories);
+  callback(that.accessoryList);
+
+  // Begin polling device status (battery + signal) once accessories are registered
+  that._startPolling();
+};
+
+// Schedule periodic getAllDevices polling for battery and signal updates
+LinkTapPlatform.prototype._startPolling = function() {
+  var that = this;
+  var minutes = this.config.pollInterval;
+
+  if (minutes === 0) {
+    this.log("Status polling disabled (pollInterval = 0); battery and signal will not update");
+    return;
+  }
+  if (minutes === undefined || minutes === null) minutes = DEFAULT_POLL_MINUTES;
+  if (minutes < MIN_POLL_MINUTES) {
+    this.log.warn("pollInterval %d is below the API minimum of %d minutes; using %d",
+      minutes, MIN_POLL_MINUTES, MIN_POLL_MINUTES);
+    minutes = MIN_POLL_MINUTES;
+  }
+
+  var intervalMs = minutes * 60 * 1000;
+  this.log("Polling LinkTap status every %d minute(s) for battery and signal", minutes);
+
+  // First poll shortly after startup, then on the interval
+  setTimeout(function() { that._pollStatus(); }, 10000);
+  this._pollTimer = setInterval(function() { that._pollStatus(); }, intervalMs);
+};
+
+// Query getAllDevices and distribute battery/signal/online status to each accessory
+LinkTapPlatform.prototype._pollStatus = function() {
+  var that = this;
+  var body = JSON.stringify({ username: username, apiKey: apiKey });
+
+  var req = https.request(_baseURL + "getAllDevices", {
+    method: 'POST',
+    headers: {
+      'Content-type': 'application/json',
+      'Content-Length': Buffer.byteLength(body)
+    }
+  }, function(res) {
+    var responseBody = '';
+    res.on('data', function(chunk) { responseBody += chunk; });
+    res.on('end', function() {
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        that.log.error("getAllDevices returned HTTP %d", res.statusCode);
+        return;
+      }
+      try {
+        var parsed = JSON.parse(responseBody);
+        debug("getAllDevices response: %s", responseBody);
+        that._applyStatus(parsed);
+      } catch (e) {
+        that.log.error("Failed to parse getAllDevices response: %s", e.message);
+      }
+    });
+  });
+
+  req.on('error', function(err) {
+    that.log.error("getAllDevices request failed: %s", err.message);
+  });
+
+  req.write(body);
+  req.end();
+};
+
+// Walk the getAllDevices response and push status into matching accessories.
+// The response nests taplinkers under devices[].deviceList[]; field names can vary
+// slightly by firmware, so matching and parsing here are deliberately defensive.
+LinkTapPlatform.prototype._applyStatus = function(parsed) {
+  var that = this;
+
+  // TEMPORARY (v1.9.1): log the raw response at normal level so the device's
+  // field names (workMode, pause state, alerts) can be confirmed without the
+  // debug env var, which child-bridge processes don't always inherit.
+  try {
+    this.log("RAW getAllDevices: %s", JSON.stringify(parsed));
+  } catch (e) {}
+
+  var gateways = parsed.devices || parsed.deviceList || [];
+  var taplinkers = [];
+
+  gateways.forEach(function(gw) {
+    var list = gw.deviceList || gw.devices || [];
+    list.forEach(function(d) { taplinkers.push(d); });
+  });
+
+  if (taplinkers.length === 0) {
+    debug("getAllDevices returned no taplinkers to match");
+    return;
+  }
+
+  taplinkers.forEach(function(d) {
+    var id = d.taplinkerId || d.deviceId || d.id;
+    if (!id) return;
+
+    var accessory = that.accessoryList.find(function(a) {
+      return a.taplinkerId && a.taplinkerId.toUpperCase() === String(id).toUpperCase();
+    });
+    if (!accessory) return;
+
+    var battery = parsePercent(d.batteryStatus !== undefined ? d.batteryStatus : d.battery);
+    var signal = parsePercent(d.signal);
+    var online;
+    if (d.status !== undefined) {
+      online = (d.status === true || d.status === 'Connected' || d.status === 'online');
+    }
+
+    // Live watering state for InUse. LinkTap reports this in the `watering` field,
+    // which is null/absent when idle and populated while water is flowing. Only
+    // override the local state when the field is actually present in the response.
+    var watering;
+    if (d.watering !== undefined) {
+      watering = (d.watering !== null && d.watering !== false);
+    }
+
+    // Combined fault detection. LinkTap reports various alerts; exact field names
+    // vary by firmware, so check a defensive set plus a generic alert flag/array.
+    // Leaves fault undefined (no override) when none of these fields are present.
+    var fault;
+    var faultFlags = [
+      d.noWater, d.waterCut, d.waterCutAlert,
+      d.fall, d.fallStatus, d.fallen,
+      d.valveBroken, d.shutdownFailure, d.broken,
+      d.clog, d.lowFlow, d.leakage, d.abnormalFlow
+    ];
+    var anyFaultField = faultFlags.some(function(v) { return v !== undefined; });
+    if (anyFaultField || d.alert !== undefined || d.alerts !== undefined) {
+      fault = faultFlags.some(function(v) { return v === true || v === 1 || v === 'true'; });
+      if (!fault && d.alert) fault = true;
+      if (!fault && Array.isArray(d.alerts) && d.alerts.length > 0) fault = true;
+    }
+
+    // Pause state, so the Home app reflects pause/resume done in the LinkTap app.
+    // Field name is unconfirmed across firmware; check the likely candidates and
+    // leave undefined (no override) when none are present.
+    var paused;
+    if (d.watactivated !== undefined) {        // some firmwares: watactivated=false when paused
+      paused = (d.watactivated === false);
+    } else if (d.paused !== undefined) {
+      paused = (d.paused === true || d.paused === 1);
+    } else if (d.pause !== undefined) {
+      paused = (d.pause === true || d.pause === 1 || (typeof d.pause === 'object' && d.pause !== null));
+    }
+
+    accessory.updateStatus(battery, signal, online, watering, fault, paused);
+  });
 };
 
 function LinkTapAccessory(log, tap) {
@@ -59,13 +217,29 @@ function LinkTapAccessory(log, tap) {
   this.duration = tap.duration; //required timer value in minutes 1..1439 minutes
   this._durationInSeconds = this.duration * 60;
   this.autoBack = tap.autoBack !== undefined ? tap.autoBack : true; //required, defaults to true
+  this.pauseHours = tap.pauseHours !== undefined ? tap.pauseHours : 24; // finite default so the schedule auto-resumes; -1 = indefinite
+  this.scheduleMode = tap.scheduleMode || 'sevenDay'; // which plan to re-activate on resume
 
   this._lastApiCall = 0;        // timestamp (ms) of the last API call, for rate limiting
   this._pendingOffTimer = null; // holds a deferred off command when rate-limited
 
+  this._active = 0;             // Characteristic.Active: 0 = inactive, 1 = active (user intent)
+  this._inUse = 0;              // Characteristic.InUse: 0 = not flowing, 1 = water flowing
+  this._paused = 0;             // 0 = schedule running, 1 = watering plan paused
+
+  // Status (updated by the platform's polling loop)
+  this._batteryLevel = 100;
+  this._statusLowBattery = 0;   // 0 = normal, 1 = low
+  this._signal = 100;
+  this._online = true;
+  this._fault = 0;              // 0 = no fault, 1 = any LinkTap alert active
+
   this.log("Found LinkTap: %s [%s]", this.name, this.taplinkerId);
 
   this._service = this.getTapService();
+  this._batteryService = this.getBatteryService();
+  this._faultService = this.getFaultService();
+  this._pauseService = this.getPauseService();
 };
 
 LinkTapAccessory.prototype.getServices = function() {
@@ -76,12 +250,21 @@ LinkTapAccessory.prototype.getServices = function() {
     .setCharacteristic(Characteristic.SerialNumber, this.taplinkerId);
   this.informationService = informationService;
 
-  return [informationService, this._service];
+  return [informationService, this._service, this._batteryService, this._faultService, this._pauseService];
 };
 
 LinkTapAccessory.prototype.getTapService = function() {
-  var tapService = new Service.Switch(this.name);
-  tapService.getCharacteristic(Characteristic.On).on('set', this.turnOnTheTap.bind(this));
+  // Modelled as an irrigation Valve so HomeKit shows Active (on/off) and InUse (watering)
+  var tapService = new Service.Valve(this.name);
+
+  tapService.getCharacteristic(Characteristic.Active)
+    .on('set', this._setActive.bind(this))
+    .on('get', function(cb) { cb(null, this._active); }.bind(this));
+
+  tapService.getCharacteristic(Characteristic.InUse)
+    .on('get', function(cb) { cb(null, this._inUse); }.bind(this));
+
+  tapService.setCharacteristic(Characteristic.ValveType, Characteristic.ValveType.IRRIGATION);
 
   /**
    * DurationTimer Characteristic
@@ -108,12 +291,137 @@ LinkTapAccessory.prototype.getTapService = function() {
     .on('get', this._getDurationTimerValue.bind(this))
     .on('set', this._setDurationTimerValue.bind(this));
 
+  // StatusFault reflects connection status: NO_FAULT when online, GENERAL_FAULT when offline
+  tapService.addCharacteristic(Characteristic.StatusFault);
+  tapService.getCharacteristic(Characteristic.StatusFault)
+    .on('get', function(cb) { cb(null, this._online ? 0 : 1); }.bind(this));
+
   return tapService;
+};
+
+// Pause switch: pauses/resumes the device's scheduled watering plans.
+// ON  -> pauseWateringPlan with the configured duration (default indefinite, -1)
+// OFF -> resume (best-effort; mirrors the app's "Deactivate" pause action)
+LinkTapAccessory.prototype.getPauseService = function() {
+  var pauseService = new Service.Switch(this.name + " Pause Schedule");
+  pauseService.getCharacteristic(Characteristic.On)
+    .on('get', function(cb) { cb(null, this._paused === 1); }.bind(this))
+    .on('set', this._setPause.bind(this));
+  return pauseService;
+};
+
+// Combined fault sensor: a single LeakSensor tile that trips on ANY LinkTap alert
+// (water cut, clog/abnormal flow, fallen device, valve shutdown failure, etc.).
+// Modelled as a leak sensor so HomeKit raises a clear alert notification.
+LinkTapAccessory.prototype.getFaultService = function() {
+  var faultService = new Service.LeakSensor(this.name + " Alert");
+  faultService.getCharacteristic(Characteristic.LeakDetected)
+    .on('get', function(cb) { cb(null, this._fault); }.bind(this));
+  return faultService;
+};
+
+// Battery service exposes battery level and a low-battery warning in HomeKit
+LinkTapAccessory.prototype.getBatteryService = function() {
+  var BatteryService = Service.Battery || Service.BatteryService;
+  var batteryService = new BatteryService(this.name + " Battery");
+
+  batteryService.getCharacteristic(Characteristic.BatteryLevel)
+    .on('get', function(cb) { cb(null, this._batteryLevel); }.bind(this));
+
+  batteryService.getCharacteristic(Characteristic.StatusLowBattery)
+    .on('get', function(cb) { cb(null, this._statusLowBattery); }.bind(this));
+
+  // LinkTap taplinkers run on replaceable batteries, so they are never "charging"
+  batteryService.setCharacteristic(
+    Characteristic.ChargingState,
+    Characteristic.ChargingState.NOT_CHARGEABLE
+  );
+
+  return batteryService;
+};
+
+// Called by the platform poll loop with the latest status for this tap
+LinkTapAccessory.prototype.updateStatus = function(batteryPct, signalPct, online, watering, fault, paused) {
+  if (batteryPct !== null && batteryPct !== undefined) {
+    this._batteryLevel = batteryPct;
+    this._statusLowBattery = batteryPct <= LOW_BATTERY_THRESHOLD ? 1 : 0;
+    if (this._batteryService) {
+      this._batteryService.updateCharacteristic(Characteristic.BatteryLevel, this._batteryLevel);
+      this._batteryService.updateCharacteristic(Characteristic.StatusLowBattery, this._statusLowBattery);
+    }
+  }
+
+  if (signalPct !== null && signalPct !== undefined) {
+    this._signal = signalPct;
+  }
+
+  if (online !== null && online !== undefined) {
+    this._online = online;
+    if (this._service) {
+      this._service.updateCharacteristic(Characteristic.StatusFault, online ? 0 : 1);
+    }
+  }
+
+  // Independent flow sensing: reflect the device's real watering state in HomeKit.
+  // This catches watering started or stopped outside HomeKit (LinkTap app, manual
+  // button, schedules). Active mirrors InUse so the tile shows on/off correctly.
+  if (watering !== null && watering !== undefined) {
+    var newInUse = watering ? 1 : 0;
+    if (newInUse !== this._inUse) {
+      this._inUse = newInUse;
+      this._active = newInUse;
+      if (this._service) {
+        this._service.updateCharacteristic(Characteristic.InUse, this._inUse);
+        this._service.updateCharacteristic(Characteristic.Active, this._active);
+      }
+      // If watering stopped externally, clear any local auto-off timer
+      if (!watering) this._resetTimer();
+    }
+  }
+
+  if (fault !== null && fault !== undefined) {
+    this._fault = fault ? 1 : 0;
+    if (this._faultService) {
+      this._faultService.updateCharacteristic(Characteristic.LeakDetected, this._fault);
+    }
+    if (this._fault) this.log.warn("%s reported an alert/fault condition", this.name);
+  }
+
+  // Reflect pause/resume performed outside HomeKit (e.g. in the LinkTap app)
+  if (paused !== null && paused !== undefined) {
+    var newPaused = paused ? 1 : 0;
+    if (newPaused !== this._paused) {
+      this._paused = newPaused;
+      if (this._pauseService) {
+        this._pauseService.updateCharacteristic(Characteristic.On, this._paused === 1);
+      }
+    }
+  }
+
+  this.log("%s status: battery %s%%, signal %s%%, %s%s%s",
+    this.name, this._batteryLevel, this._signal,
+    this._online ? "online" : "offline",
+    (watering !== undefined ? (watering ? ", watering" : ", idle") : ""),
+    (this._fault ? ", ALERT" : ""));
 };
 
 LinkTapAccessory.prototype.identify = function(callback) {
   this.log("%s - Identify", this.name);
   callback();
+};
+
+// Valve Active set handler. Maps Active (0/1) onto the watering logic and
+// updates InUse to reflect whether water is flowing.
+LinkTapAccessory.prototype._setActive = function(value, callback) {
+  var on = (value === Characteristic.Active.ACTIVE || value === 1);
+  this._active = on ? 1 : 0;
+  this._inUse = on ? 1 : 0;
+
+  if (this._service) {
+    this._service.updateCharacteristic(Characteristic.InUse, this._inUse);
+  }
+
+  this.turnOnTheTap(on, callback);
 };
 
 LinkTapAccessory.prototype.turnOnTheTap = function(on, callback) {
@@ -196,6 +504,94 @@ LinkTapAccessory.prototype._sendInstantMode = function(on, callback) {
   req.end();
 };
 
+// Pause switch handler: ON pauses the watering plan, OFF resumes it.
+LinkTapAccessory.prototype._setPause = function(value, callback) {
+  var pause = (value === true || value === 1);
+  this._paused = pause ? 1 : 0;
+  if (pause) {
+    this._pauseWateringPlan(callback);
+  } else {
+    this._resumeWateringPlan(callback);
+  }
+};
+
+// Map a configured schedule mode to its activate endpoint
+var SCHEDULE_MODE_ENDPOINTS = {
+  sevenDay: 'activateSevenDayMode',
+  interval: 'activateIntervalMode',
+  oddEven: 'activateOddEvenMode',
+  month: 'activateMonthMode',
+  calendar: 'activateCalendarMode'
+};
+
+// Pause the device's scheduled watering plans for a finite duration so the
+// schedule auto-resumes even if an explicit resume is missed. pauseHours -1
+// pauses indefinitely (relies on the explicit resume below to restore it).
+LinkTapAccessory.prototype._pauseWateringPlan = function(callback) {
+  var data = {
+    username: username,
+    apiKey: apiKey,
+    gatewayId: gatewayId,
+    taplinkerId: this.taplinkerId,
+    pauseDuration: this.pauseHours,
+    overwrite: 'always'
+  };
+  this.log("%s watering plan paused (%s)", this.name,
+    this.pauseHours === -1 ? "indefinite" : this.pauseHours + "h");
+  this._postLinkTap("pauseWateringPlan", data, callback);
+};
+
+// Resume by re-activating the configured watering plan mode. The LinkTap API has
+// no standalone "resume" call (pauseDuration 0 is rejected with HTTP 400), so the
+// app's "Deactivate" is implemented as re-activating the existing schedule.
+LinkTapAccessory.prototype._resumeWateringPlan = function(callback) {
+  var endpoint = SCHEDULE_MODE_ENDPOINTS[this.scheduleMode] || SCHEDULE_MODE_ENDPOINTS.sevenDay;
+  var data = {
+    username: username,
+    apiKey: apiKey,
+    gatewayId: gatewayId,
+    taplinkerId: this.taplinkerId
+  };
+  this.log("%s watering plan resumed (re-activating %s)", this.name, endpoint);
+  this._postLinkTap(endpoint, data, callback);
+};
+
+// Generic POST helper for LinkTap endpoints that just need a success/fail result
+LinkTapAccessory.prototype._postLinkTap = function(endpoint, data, callback) {
+  var self = this;
+  var body = JSON.stringify(data);
+  debug("%s body %s", endpoint, body);
+
+  var req = https.request(_baseURL + endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-type': 'application/json',
+      'Content-Length': Buffer.byteLength(body)
+    }
+  }, function(res) {
+    var responseBody = '';
+    res.on('data', function(chunk) { responseBody += chunk; });
+    res.on('end', function() {
+      debug('%s STATUS: %d %s', endpoint, res.statusCode, responseBody);
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        if (callback) callback();
+      } else {
+        var err = new Error(endpoint + " returned HTTP " + res.statusCode + " " + responseBody);
+        self.log.error(err.message);
+        if (callback) callback(err);
+      }
+    });
+  });
+
+  req.on('error', function(error) {
+    self.log.error("%s request failed: %s", endpoint, error.message);
+    if (callback) callback(error);
+  });
+
+  req.write(body);
+  req.end();
+};
+
 LinkTapAccessory.prototype._startTimer = function() {
   var durationInMiliseconds = this._durationInSeconds * 1000;
 
@@ -212,7 +608,10 @@ LinkTapAccessory.prototype._onTimeout = function() {
   this.log("Switching off the tap %s", this.name);
   // With autoBack enabled the LinkTap device stops watering on its own when the
   // duration elapses, so we only need to reflect that state back in HomeKit here.
-  this._service.getCharacteristic(Characteristic.On).updateValue(false);
+  this._active = 0;
+  this._inUse = 0;
+  this._service.updateCharacteristic(Characteristic.Active, 0);
+  this._service.updateCharacteristic(Characteristic.InUse, 0);
   this._timer = 0;
 };
 
@@ -228,11 +627,8 @@ LinkTapAccessory.prototype._setDurationTimerValue = function(value, callback) {
 };
 
 /**
- * Future work...
- * device.Status: Connected/Disconnected 	-> Characteristic.Active (https://github.com/KhaosT/HAP-NodeJS/blob/master/lib/gen/HomeKitTypes.js#L29)
- * device.BatteryLevel: 0..100%		-> Characteristic.BatteryLevel https://github.com/KhaosT/HAP-NodeJS/blob/master/lib/gen/HomeKitTypes.js#L159
- * ?device.InUse: Yes/No			-> Characteristic.InUse (https://github.com/KhaosT/HAP-NodeJS/blob/master/lib/gen/HomeKitTypes.js#L948)
- * ?Characteristic.SetupEndpoints
- * ?Characteristic.StatusActive
- * ?Characteristic.StatusLowBattery
+ * Possible future work:
+ * - Characteristic.InUse / active watering state reflected live from polling
+ * - Eco mode (eco / ecoOn / ecoOff) exposed as configurable options
+ * - Water volume reporting for G2/G2S flow-meter devices
  **/

--- a/index.js
+++ b/index.js
@@ -294,6 +294,7 @@ function LinkTapAccessory(log, tap, platform) {
   this.duration = (typeof tap.duration === 'number' && tap.duration >= 1) ? tap.duration : 10; //timer value in minutes 1..1439; defaults to 10 if missing/invalid
   this._durationInSeconds = this.duration * 60;
   this.autoBack = tap.autoBack !== undefined ? tap.autoBack : true; //required, defaults to true
+  this.useValve = tap.useValve !== undefined ? tap.useValve : true; // valve (Active+InUse) vs plain switch; switch is the legacy model
   this.pauseHours = tap.pauseHours !== undefined ? tap.pauseHours : 24; // finite default so the schedule auto-resumes; -1 = indefinite
   this.scheduleMode = tap.scheduleMode || 'sevenDay'; // which plan to re-activate on resume
   this._detectedMode = null;    // mode auto-detected from polling (workMode), if recognised
@@ -333,17 +334,28 @@ LinkTapAccessory.prototype.getServices = function() {
 };
 
 LinkTapAccessory.prototype.getTapService = function() {
-  // Modelled as an irrigation Valve so HomeKit shows Active (on/off) and InUse (watering)
-  var tapService = new Service.Valve(this.name);
+  var tapService;
 
-  tapService.getCharacteristic(Characteristic.Active)
-    .on('set', this._setActive.bind(this))
-    .on('get', function(cb) { cb(null, this._active); }.bind(this));
+  if (this.useValve) {
+    // Irrigation Valve so HomeKit shows Active (on/off) and InUse (watering)
+    tapService = new Service.Valve(this.name);
 
-  tapService.getCharacteristic(Characteristic.InUse)
-    .on('get', function(cb) { cb(null, this._inUse); }.bind(this));
+    tapService.getCharacteristic(Characteristic.Active)
+      .on('set', this._setActive.bind(this))
+      .on('get', function(cb) { cb(null, this._active); }.bind(this));
 
-  tapService.setCharacteristic(Characteristic.ValveType, Characteristic.ValveType.IRRIGATION);
+    tapService.getCharacteristic(Characteristic.InUse)
+      .on('get', function(cb) { cb(null, this._inUse); }.bind(this));
+
+    tapService.setCharacteristic(Characteristic.ValveType, Characteristic.ValveType.IRRIGATION);
+  } else {
+    // Legacy plain Switch (on/off only, no independent flow sensing)
+    tapService = new Service.Switch(this.name);
+
+    tapService.getCharacteristic(Characteristic.On)
+      .on('set', this._setSwitchOn.bind(this))
+      .on('get', function(cb) { cb(null, this._active === 1); }.bind(this));
+  }
 
   // DurationTimer is defined once at registration (see module.exports)
   tapService.addCharacteristic(Characteristic.DurationTimer);
@@ -436,10 +448,7 @@ LinkTapAccessory.prototype.updateStatus = function(batteryPct, signalPct, online
     if (newInUse !== this._inUse) {
       this._inUse = newInUse;
       this._active = newInUse;
-      if (this._service) {
-        this._service.updateCharacteristic(Characteristic.InUse, this._inUse);
-        this._service.updateCharacteristic(Characteristic.Active, this._active);
-      }
+      this._reflectWateringState();
       // If watering stopped externally, clear any local auto-off timer
       if (!watering) this._resetTimer();
     }
@@ -500,6 +509,25 @@ LinkTapAccessory.prototype._setActive = function(value, callback) {
   }
 
   this.turnOnTheTap(on, callback);
+};
+
+// Legacy Switch On set handler (when useValve is false).
+LinkTapAccessory.prototype._setSwitchOn = function(value, callback) {
+  var on = (value === true || value === 1);
+  this._active = on ? 1 : 0;
+  this._inUse = on ? 1 : 0;
+  this.turnOnTheTap(on, callback);
+};
+
+// Reflect the current watering state onto whichever service type is in use.
+LinkTapAccessory.prototype._reflectWateringState = function() {
+  if (!this._service) return;
+  if (this.useValve) {
+    this._service.updateCharacteristic(Characteristic.InUse, this._inUse);
+    this._service.updateCharacteristic(Characteristic.Active, this._active);
+  } else {
+    this._service.updateCharacteristic(Characteristic.On, this._active === 1);
+  }
 };
 
 LinkTapAccessory.prototype.turnOnTheTap = function(on, callback) {
@@ -731,10 +759,7 @@ LinkTapAccessory.prototype._onTimeout = function() {
   // duration elapses, so we only need to reflect that state back in HomeKit here.
   this._active = 0;
   this._inUse = 0;
-  if (this._service) {
-    this._service.updateCharacteristic(Characteristic.Active, 0);
-    this._service.updateCharacteristic(Characteristic.InUse, 0);
-  }
+  this._reflectWateringState();
   this._timer = 0;
 };
 

--- a/index.js
+++ b/index.js
@@ -38,6 +38,25 @@ module.exports = function(homebridge) {
   DurationTimer.UUID = 'CDC6551D-2D1B-4CC1-A5AE-0200844A7BC3';
   Characteristic.DurationTimer = DurationTimer;
 
+  // Custom WaterVolume characteristic (litres). Visible in Eve / Controller for
+  // HomeKit; the stock Home app ignores unrecognised characteristics harmlessly.
+  class WaterVolume extends Characteristic {
+    constructor() {
+      super('Water Volume', 'E863F10C-079E-48FF-8F27-9C2605A29F52');
+      this.setProps({
+        format: 'float',
+        unit: 'litre',
+        minValue: 0,
+        maxValue: 1000000,
+        minStep: 0.1,
+        perms: ['pr', 'ev']
+      });
+      this.value = this.getDefaultValue();
+    }
+  }
+  WaterVolume.UUID = 'E863F10C-079E-48FF-8F27-9C2605A29F52';
+  Characteristic.WaterVolume = WaterVolume;
+
   homebridge.registerPlatform("homebridge-platform-linktap", "LinkTapPlatform", LinkTapPlatform);
 };
 
@@ -208,23 +227,37 @@ LinkTapPlatform.prototype._applyStatus = function(parsed) {
       watering = (d.watering !== null && d.watering !== false);
     }
 
-    // Combined fault detection using the device's actual alert fields
-    // (confirmed from a live getAllDevices response). A couple of legacy
-    // fallbacks are kept harmlessly in case firmware naming differs.
+    // Combined fault detection using the device's actual alert fields. The status
+    // response uses fall/leakFlag/clogFlag; the alarm API uses fallFlag/pcFlag/
+    // pbFlag. Freeze fields are checked defensively (name unconfirmed in the poll
+    // response; freeze may only arrive via webhook). Both sets are covered.
     var fault;
     var faultFlags = [
       d.noWater,      // water supply cut off
-      d.fall,         // device has fallen
-      d.valveBroken,  // valve failure
-      d.leakFlag,     // leak detected
-      d.clogFlag,     // clog / abnormal flow
-      d.waterCut, d.fallStatus, d.shutdownFailure // legacy fallbacks
+      d.valveBroken,  // valve shut-off failure
+      d.fall,         // device fallen (status field)
+      d.fallFlag,     // device fallen (alarm-API name)
+      d.leakFlag,     // leak / abnormal flow
+      d.clogFlag,     // clog / blockage
+      d.pcFlag,       // unusually low flow
+      d.pbFlag,       // unusually high flow
+      d.freeze, d.freezeFlag, d.frzFlag // freeze alert (defensive; name unconfirmed)
     ];
     var anyFaultField = faultFlags.some(function(v) { return v !== undefined; });
     if (anyFaultField || d.alert !== undefined || d.alerts !== undefined) {
       fault = faultFlags.some(function(v) { return v === true || v === 1 || v === 'true'; });
       if (!fault && d.alert) fault = true;
       if (!fault && Array.isArray(d.alerts) && d.alerts.length > 0) fault = true;
+    }
+
+    // Water volume of the current/last cycle (G2/G2S flow-meter models). `vol` is
+    // ml; `vel` is the running-slot accumulated volume. Exposed via a custom
+    // characteristic (visible in Eve / Controller for HomeKit).
+    var volumeMl;
+    if (d.vol !== undefined && typeof d.vol === 'number') {
+      volumeMl = d.vol;
+    } else if (d.vel !== undefined && typeof d.vel === 'number') {
+      volumeMl = d.vel;
     }
 
     // Auto-detect the active watering mode so resume re-activates the right plan.
@@ -247,7 +280,7 @@ LinkTapPlatform.prototype._applyStatus = function(parsed) {
       paused = (d.pause === true || d.pause === 1 || (typeof d.pause === 'object' && d.pause !== null));
     }
 
-    accessory.updateStatus(battery, signal, online, watering, fault, paused);
+    accessory.updateStatus(battery, signal, online, watering, fault, paused, volumeMl);
   });
 };
 
@@ -258,7 +291,7 @@ function LinkTapAccessory(log, tap, platform) {
   this.name = tap.name; //required friendly name
   this.location = tap.location; //optional fyi
   this.taplinkerId = tap.taplinkerId; //required xxxx-xxxx-xxxx-xxxx (no hyphens)
-  this.duration = tap.duration; //required timer value in minutes 1..1439 minutes
+  this.duration = (typeof tap.duration === 'number' && tap.duration >= 1) ? tap.duration : 10; //timer value in minutes 1..1439; defaults to 10 if missing/invalid
   this._durationInSeconds = this.duration * 60;
   this.autoBack = tap.autoBack !== undefined ? tap.autoBack : true; //required, defaults to true
   this.pauseHours = tap.pauseHours !== undefined ? tap.pauseHours : 24; // finite default so the schedule auto-resumes; -1 = indefinite
@@ -270,13 +303,14 @@ function LinkTapAccessory(log, tap, platform) {
 
   this._active = 0;             // Characteristic.Active: 0 = inactive, 1 = active (user intent)
   this._inUse = 0;              // Characteristic.InUse: 0 = not flowing, 1 = water flowing
-  this._paused = 0;             // 0 = schedule running, 1 = watering plan paused
+  this._paused = 0;             // 0 = running (switch OFF), 1 = paused (switch ON)
 
   // Status (updated by the platform's polling loop)
   this._batteryLevel = 100;
   this._statusLowBattery = 0;   // 0 = normal, 1 = low
   this._signal = 100;
   this._online = true;
+  this._volume = 0;             // last reported water volume in litres (G2/G2S)
   this._fault = 0;              // 0 = no fault, 1 = any LinkTap alert active
 
   this.log("Found LinkTap: %s [%s]", this.name, this.taplinkerId);
@@ -284,7 +318,7 @@ function LinkTapAccessory(log, tap, platform) {
   this._service = this.getTapService();
   this._batteryService = this.getBatteryService();
   this._faultService = this.getFaultService();
-  this._pauseService = this.getPauseService();
+  this._scheduleService = this.getScheduleService();
 };
 
 LinkTapAccessory.prototype.getServices = function() {
@@ -295,7 +329,7 @@ LinkTapAccessory.prototype.getServices = function() {
     .setCharacteristic(Characteristic.SerialNumber, this.taplinkerId);
   this.informationService = informationService;
 
-  return [informationService, this._service, this._batteryService, this._faultService, this._pauseService];
+  return [informationService, this._service, this._batteryService, this._faultService, this._scheduleService];
 };
 
 LinkTapAccessory.prototype.getTapService = function() {
@@ -323,17 +357,22 @@ LinkTapAccessory.prototype.getTapService = function() {
   tapService.getCharacteristic(Characteristic.StatusFault)
     .on('get', function(cb) { cb(null, this._online ? 0 : 1); }.bind(this));
 
+  // Water volume of the current/last cycle (G2/G2S). Visible in Eve / Controller
+  // for HomeKit; ignored by the stock Home app.
+  tapService.addCharacteristic(Characteristic.WaterVolume);
+  tapService.getCharacteristic(Characteristic.WaterVolume)
+    .on('get', function(cb) { cb(null, this._volume); }.bind(this));
+
   return tapService;
 };
 
 // Pause switch: pauses/resumes the device's scheduled watering plans.
-// ON  -> pauseWateringPlan with the configured duration (default indefinite, -1)
-// OFF -> resume (best-effort; mirrors the app's "Deactivate" pause action)
-LinkTapAccessory.prototype.getPauseService = function() {
+// ON = paused (pauses the plan for the configured duration), OFF = running (resumes).
+LinkTapAccessory.prototype.getScheduleService = function() {
   var pauseService = new Service.Switch(this.name + " Pause Schedule");
   pauseService.getCharacteristic(Characteristic.On)
     .on('get', function(cb) { cb(null, this._paused === 1); }.bind(this))
-    .on('set', this._setPause.bind(this));
+    .on('set', this._setSchedule.bind(this));
   return pauseService;
 };
 
@@ -368,7 +407,7 @@ LinkTapAccessory.prototype.getBatteryService = function() {
 };
 
 // Called by the platform poll loop with the latest status for this tap
-LinkTapAccessory.prototype.updateStatus = function(batteryPct, signalPct, online, watering, fault, paused) {
+LinkTapAccessory.prototype.updateStatus = function(batteryPct, signalPct, online, watering, fault, paused, volumeMl) {
   if (batteryPct !== null && batteryPct !== undefined) {
     this._batteryLevel = batteryPct;
     this._statusLowBattery = batteryPct <= LOW_BATTERY_THRESHOLD ? 1 : 0;
@@ -414,13 +453,25 @@ LinkTapAccessory.prototype.updateStatus = function(batteryPct, signalPct, online
     if (this._fault) this.log.warn("%s reported an alert/fault condition", this.name);
   }
 
-  // Reflect pause/resume performed outside HomeKit (e.g. in the LinkTap app)
+  // Reflect pause/resume performed outside HomeKit (e.g. in the LinkTap app).
+  // Switch is ON when the schedule is paused.
   if (paused !== null && paused !== undefined) {
     var newPaused = paused ? 1 : 0;
     if (newPaused !== this._paused) {
       this._paused = newPaused;
-      if (this._pauseService) {
-        this._pauseService.updateCharacteristic(Characteristic.On, this._paused === 1);
+      if (this._scheduleService) {
+        this._scheduleService.updateCharacteristic(Characteristic.On, this._paused === 1);
+      }
+    }
+  }
+
+  // Water volume (ml -> litres) for G2/G2S flow-meter models
+  if (volumeMl !== null && volumeMl !== undefined) {
+    var litres = Math.round((volumeMl / 1000) * 10) / 10;
+    if (litres !== this._volume) {
+      this._volume = litres;
+      if (this._service) {
+        this._service.updateCharacteristic(Characteristic.WaterVolume, this._volume);
       }
     }
   }
@@ -487,13 +538,16 @@ LinkTapAccessory.prototype.turnOnTheTap = function(on, callback) {
 // Shared helper that sends an activateInstantMode request (on or off)
 LinkTapAccessory.prototype._sendInstantMode = function(on, callback) {
   var self = this;
+  // Use the live duration set via HomeKit's DurationTimer, not just the static
+  // config value, so changing the duration in HomeKit actually takes effect.
+  var durationMinutes = Math.max(1, Math.round(this._durationInSeconds / 60));
   var data = {
     username: username,
     apiKey: apiKey,
     gatewayId: gatewayId,
     taplinkerId: this.taplinkerId,
     action: on,
-    duration: on ? this.duration : 0,
+    duration: on ? durationMinutes : 0,
     autoBack: this.autoBack
   };
 
@@ -532,7 +586,7 @@ LinkTapAccessory.prototype._sendInstantMode = function(on, callback) {
 };
 
 // Pause switch handler: ON pauses the watering plan, OFF resumes it.
-LinkTapAccessory.prototype._setPause = function(value, callback) {
+LinkTapAccessory.prototype._setSchedule = function(value, callback) {
   var pause = (value === true || value === 1);
   this._paused = pause ? 1 : 0;
   if (pause) {
@@ -551,16 +605,16 @@ var SCHEDULE_MODE_ENDPOINTS = {
   calendar: 'activateCalendarMode'
 };
 
-// Map the device's reported workMode code to a schedule mode. Only "T" (7-Day)
-// is confirmed from live hardware; the rest are best-guess and safely fall back
-// to the user's configured scheduleMode when a code isn't recognised.
+// Map the device's reported workMode code to a schedule mode, per the official
+// LinkTap API: M=Instant, I=Interval, T=7-day, O=Odd-even, D=Calendar, Y=Month,
+// N=No mode. Only the schedule modes are listed here; Instant and No-mode have no
+// schedule to re-activate, so they fall through to the skip-with-warning path.
 var WORKMODE_TO_SCHEDULE = {
-  'T': 'sevenDay',
   'I': 'interval',
+  'T': 'sevenDay',
   'O': 'oddEven',
-  'M': 'month',
-  'Y': 'calendar',
-  'C': 'calendar'
+  'D': 'calendar',
+  'Y': 'month'
 };
 
 // Pause the device's scheduled watering plans for a finite duration so the
@@ -677,8 +731,10 @@ LinkTapAccessory.prototype._onTimeout = function() {
   // duration elapses, so we only need to reflect that state back in HomeKit here.
   this._active = 0;
   this._inUse = 0;
-  this._service.updateCharacteristic(Characteristic.Active, 0);
-  this._service.updateCharacteristic(Characteristic.InUse, 0);
+  if (this._service) {
+    this._service.updateCharacteristic(Characteristic.Active, 0);
+    this._service.updateCharacteristic(Characteristic.InUse, 0);
+  }
   this._timer = 0;
 };
 
@@ -688,14 +744,17 @@ LinkTapAccessory.prototype._getDurationTimerValue = function(callback) {
 };
 
 LinkTapAccessory.prototype._setDurationTimerValue = function(value, callback) {
-  this.log("Setting the Tap duration to: " + value / 60 + " minutes");
-  this._durationInSeconds = value;
+  // Clamp to the characteristic's range so the instant-mode duration stays valid
+  var seconds = Math.max(60, Math.min(86340, value));
+  this._durationInSeconds = seconds;
+  this.log("Setting the Tap duration to: " + seconds / 60 + " minutes");
   callback();
 };
 
 /**
  * Possible future work:
  * - Eco mode (eco / ecoOn / ecoOff) exposed as configurable options
- * - Water volume reporting (vel/vol) for G2/G2S flow-meter devices
- * - Webhook listener for push updates instead of polling (lower latency)
+ * - dismissAlarm endpoint to make the fault sensor actionable (clear alerts)
+ * - Webhook listener (setWebHookUrl) for push updates instead of polling:
+ *   instant watering/battery/alert events and reliable freeze + pause sync
  **/

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const RATE_LIMIT_MS = 15000;        // activateInstantMode: min 15s between call
 const MIN_POLL_MINUTES = 5;         // getAllDevices: manufacturer limits status polling to every 5 min
 const DEFAULT_POLL_MINUTES = 5;
 const LOW_BATTERY_THRESHOLD = 20;   // percent at or below which HomeKit shows a low-battery warning
-var Service, Characteristic, Accessory, UUIDGen;
+var Service, Characteristic;
 var debug = require('debug')('linktap');
 
 var username, apiKey, gatewayId;
@@ -20,15 +20,29 @@ function parsePercent(val) {
 module.exports = function(homebridge) {
   Service = homebridge.hap.Service;
   Characteristic = homebridge.hap.Characteristic;
-  Accessory = homebridge.hap.Accessory;
-  UUIDGen = homebridge.hap.uuid;
 
-  homebridge.registerPlatform("homebridge-platform-linktap-v2", "LinkTapPlatform", LinkTapPlatform);
+  // Define the custom DurationTimer characteristic once, at registration time
+  class DurationTimer extends Characteristic {
+    constructor() {
+      super('Duration Timer', 'CDC6551D-2D1B-4CC1-A5AE-0200844A7BC3');
+      this.setProps({
+        format: 'int',
+        unit: 's',
+        perms: ['pr', 'pw'],
+        minValue: 60,
+        maxValue: 86340,
+      });
+      this.value = this.getDefaultValue();
+    }
+  }
+  DurationTimer.UUID = 'CDC6551D-2D1B-4CC1-A5AE-0200844A7BC3';
+  Characteristic.DurationTimer = DurationTimer;
+
+  homebridge.registerPlatform("homebridge-platform-linktap", "LinkTapPlatform", LinkTapPlatform);
 };
 
 function LinkTapPlatform(log, config, api) {
   this.log = log;
-  this.debug = log.debug;
 
   if (!config) {
     log.warn("Ignoring LinkTap Platform setup because it is not configured");
@@ -56,7 +70,7 @@ LinkTapPlatform.prototype.accessories = function(callback) {
 
   //tap is a config for each of the linktaps.
   that.config.taps.forEach(function(tap) {
-    that.accessoryList.push(new LinkTapAccessory(that.log, tap));
+    that.accessoryList.push(new LinkTapAccessory(that.log, tap, that));
   });
   callback(that.accessoryList);
 
@@ -91,6 +105,17 @@ LinkTapPlatform.prototype._startPolling = function() {
 // Query getAllDevices and distribute battery/signal/online status to each accessory
 LinkTapPlatform.prototype._pollStatus = function() {
   var that = this;
+  this._fetchDevices(function(err, parsed) {
+    if (err) {
+      that.log.error("getAllDevices request failed: %s", err.message);
+      return;
+    }
+    that._applyStatus(parsed);
+  });
+};
+
+// Low-level getAllDevices fetch. Calls back with (err, parsedResponse).
+LinkTapPlatform.prototype._fetchDevices = function(callback) {
   var body = JSON.stringify({ username: username, apiKey: apiKey });
 
   var req = https.request(_baseURL + "getAllDevices", {
@@ -104,25 +129,39 @@ LinkTapPlatform.prototype._pollStatus = function() {
     res.on('data', function(chunk) { responseBody += chunk; });
     res.on('end', function() {
       if (res.statusCode < 200 || res.statusCode >= 300) {
-        that.log.error("getAllDevices returned HTTP %d", res.statusCode);
-        return;
+        return callback(new Error("getAllDevices returned HTTP " + res.statusCode));
       }
       try {
-        var parsed = JSON.parse(responseBody);
-        debug("getAllDevices response: %s", responseBody);
-        that._applyStatus(parsed);
+        callback(null, JSON.parse(responseBody));
       } catch (e) {
-        that.log.error("Failed to parse getAllDevices response: %s", e.message);
+        callback(new Error("Failed to parse getAllDevices response: " + e.message));
       }
     });
   });
 
-  req.on('error', function(err) {
-    that.log.error("getAllDevices request failed: %s", err.message);
-  });
-
+  req.on('error', function(err) { callback(err); });
   req.write(body);
   req.end();
+};
+
+// Read the live workMode for a specific taplinker from a fresh getAllDevices call.
+// Calls back with (err, scheduleMode) where scheduleMode may be null if unknown.
+LinkTapPlatform.prototype.fetchLiveMode = function(taplinkerId, callback) {
+  this._fetchDevices(function(err, parsed) {
+    if (err) return callback(err);
+    var gateways = parsed.devices || parsed.deviceList || [];
+    var mode = null;
+    gateways.forEach(function(gw) {
+      var list = gw.taplinker || gw.deviceList || gw.devices || [];
+      list.forEach(function(d) {
+        var id = d.taplinkerId || d.deviceId || d.id;
+        if (id && String(id).toUpperCase() === String(taplinkerId).toUpperCase() && d.workMode !== undefined) {
+          mode = WORKMODE_TO_SCHEDULE[d.workMode] || null;
+        }
+      });
+    });
+    callback(null, mode);
+  });
 };
 
 // Walk the getAllDevices response and push status into matching accessories.
@@ -130,11 +169,13 @@ LinkTapPlatform.prototype._pollStatus = function() {
 // slightly by firmware, so matching and parsing here are deliberately defensive.
 LinkTapPlatform.prototype._applyStatus = function(parsed) {
   var that = this;
+
   var gateways = parsed.devices || parsed.deviceList || [];
   var taplinkers = [];
 
   gateways.forEach(function(gw) {
-    var list = gw.deviceList || gw.devices || [];
+    // Real response nests taplinkers under `taplinker`; keep older fallbacks too
+    var list = gw.taplinker || gw.deviceList || gw.devices || [];
     list.forEach(function(d) { taplinkers.push(d); });
   });
 
@@ -167,15 +208,17 @@ LinkTapPlatform.prototype._applyStatus = function(parsed) {
       watering = (d.watering !== null && d.watering !== false);
     }
 
-    // Combined fault detection. LinkTap reports various alerts; exact field names
-    // vary by firmware, so check a defensive set plus a generic alert flag/array.
-    // Leaves fault undefined (no override) when none of these fields are present.
+    // Combined fault detection using the device's actual alert fields
+    // (confirmed from a live getAllDevices response). A couple of legacy
+    // fallbacks are kept harmlessly in case firmware naming differs.
     var fault;
     var faultFlags = [
-      d.noWater, d.waterCut, d.waterCutAlert,
-      d.fall, d.fallStatus, d.fallen,
-      d.valveBroken, d.shutdownFailure, d.broken,
-      d.clog, d.lowFlow, d.leakage, d.abnormalFlow
+      d.noWater,      // water supply cut off
+      d.fall,         // device has fallen
+      d.valveBroken,  // valve failure
+      d.leakFlag,     // leak detected
+      d.clogFlag,     // clog / abnormal flow
+      d.waterCut, d.fallStatus, d.shutdownFailure // legacy fallbacks
     ];
     var anyFaultField = faultFlags.some(function(v) { return v !== undefined; });
     if (anyFaultField || d.alert !== undefined || d.alerts !== undefined) {
@@ -184,12 +227,33 @@ LinkTapPlatform.prototype._applyStatus = function(parsed) {
       if (!fault && Array.isArray(d.alerts) && d.alerts.length > 0) fault = true;
     }
 
-    accessory.updateStatus(battery, signal, online, watering, fault);
+    // Auto-detect the active watering mode so resume re-activates the right plan.
+    // Confirmed: "T" = 7-Day mode. Other codes are best-guess and fall back to
+    // the configured scheduleMode when unknown.
+    if (d.workMode !== undefined) {
+      var mapped = WORKMODE_TO_SCHEDULE[d.workMode];
+      if (mapped) accessory._detectedMode = mapped;
+    }
+
+    // Pause state, so the Home app reflects pause/resume done in the LinkTap app.
+    // Field name is unconfirmed across firmware; check the likely candidates and
+    // leave undefined (no override) when none are present.
+    var paused;
+    if (d.watactivated !== undefined) {        // some firmwares: watactivated=false when paused
+      paused = (d.watactivated === false);
+    } else if (d.paused !== undefined) {
+      paused = (d.paused === true || d.paused === 1);
+    } else if (d.pause !== undefined) {
+      paused = (d.pause === true || d.pause === 1 || (typeof d.pause === 'object' && d.pause !== null));
+    }
+
+    accessory.updateStatus(battery, signal, online, watering, fault, paused);
   });
 };
 
-function LinkTapAccessory(log, tap) {
+function LinkTapAccessory(log, tap, platform) {
   this.log = log;
+  this.platform = platform;
 
   this.name = tap.name; //required friendly name
   this.location = tap.location; //optional fyi
@@ -199,6 +263,7 @@ function LinkTapAccessory(log, tap) {
   this.autoBack = tap.autoBack !== undefined ? tap.autoBack : true; //required, defaults to true
   this.pauseHours = tap.pauseHours !== undefined ? tap.pauseHours : 24; // finite default so the schedule auto-resumes; -1 = indefinite
   this.scheduleMode = tap.scheduleMode || 'sevenDay'; // which plan to re-activate on resume
+  this._detectedMode = null;    // mode auto-detected from polling (workMode), if recognised
 
   this._lastApiCall = 0;        // timestamp (ms) of the last API call, for rate limiting
   this._pendingOffTimer = null; // holds a deferred off command when rate-limited
@@ -246,25 +311,7 @@ LinkTapAccessory.prototype.getTapService = function() {
 
   tapService.setCharacteristic(Characteristic.ValveType, Characteristic.ValveType.IRRIGATION);
 
-  /**
-   * DurationTimer Characteristic
-   **/
-  class DurationTimer extends Characteristic {
-    constructor() {
-      super('Duration Timer', 'CDC6551D-2D1B-4CC1-A5AE-0200844A7BC3');
-      this.setProps({
-        format: 'int',
-        unit: 's',
-        perms: ['pr', 'pw'],
-        minValue: 60,
-        maxValue: 86340,
-      });
-      this.value = this.getDefaultValue();
-    }
-  }
-  DurationTimer.UUID = 'CDC6551D-2D1B-4CC1-A5AE-0200844A7BC3';
-  Characteristic.DurationTimer = DurationTimer;
-
+  // DurationTimer is defined once at registration (see module.exports)
   tapService.addCharacteristic(Characteristic.DurationTimer);
   tapService.updateCharacteristic(Characteristic.DurationTimer, this._durationInSeconds);
   tapService.getCharacteristic(Characteristic.DurationTimer)
@@ -321,7 +368,7 @@ LinkTapAccessory.prototype.getBatteryService = function() {
 };
 
 // Called by the platform poll loop with the latest status for this tap
-LinkTapAccessory.prototype.updateStatus = function(batteryPct, signalPct, online, watering, fault) {
+LinkTapAccessory.prototype.updateStatus = function(batteryPct, signalPct, online, watering, fault, paused) {
   if (batteryPct !== null && batteryPct !== undefined) {
     this._batteryLevel = batteryPct;
     this._statusLowBattery = batteryPct <= LOW_BATTERY_THRESHOLD ? 1 : 0;
@@ -365,6 +412,17 @@ LinkTapAccessory.prototype.updateStatus = function(batteryPct, signalPct, online
       this._faultService.updateCharacteristic(Characteristic.LeakDetected, this._fault);
     }
     if (this._fault) this.log.warn("%s reported an alert/fault condition", this.name);
+  }
+
+  // Reflect pause/resume performed outside HomeKit (e.g. in the LinkTap app)
+  if (paused !== null && paused !== undefined) {
+    var newPaused = paused ? 1 : 0;
+    if (newPaused !== this._paused) {
+      this._paused = newPaused;
+      if (this._pauseService) {
+        this._pauseService.updateCharacteristic(Characteristic.On, this._paused === 1);
+      }
+    }
   }
 
   this.log("%s status: battery %s%%, signal %s%%, %s%s%s",
@@ -440,7 +498,7 @@ LinkTapAccessory.prototype._sendInstantMode = function(on, callback) {
   };
 
   var body = JSON.stringify(data);
-  debug("body", body);
+  debug("activateInstantMode body %s", body);
   this._lastApiCall = Date.now();
 
   var req = https.request(_baseURL + "activateInstantMode", {
@@ -493,6 +551,18 @@ var SCHEDULE_MODE_ENDPOINTS = {
   calendar: 'activateCalendarMode'
 };
 
+// Map the device's reported workMode code to a schedule mode. Only "T" (7-Day)
+// is confirmed from live hardware; the rest are best-guess and safely fall back
+// to the user's configured scheduleMode when a code isn't recognised.
+var WORKMODE_TO_SCHEDULE = {
+  'T': 'sevenDay',
+  'I': 'interval',
+  'O': 'oddEven',
+  'M': 'month',
+  'Y': 'calendar',
+  'C': 'calendar'
+};
+
 // Pause the device's scheduled watering plans for a finite duration so the
 // schedule auto-resumes even if an explicit resume is missed. pauseHours -1
 // pauses indefinitely (relies on the explicit resume below to restore it).
@@ -510,19 +580,47 @@ LinkTapAccessory.prototype._pauseWateringPlan = function(callback) {
   this._postLinkTap("pauseWateringPlan", data, callback);
 };
 
-// Resume by re-activating the configured watering plan mode. The LinkTap API has
-// no standalone "resume" call (pauseDuration 0 is rejected with HTTP 400), so the
-// app's "Deactivate" is implemented as re-activating the existing schedule.
+// Resume by re-activating the watering plan mode that is ACTUALLY active right
+// now. The LinkTap API has no standalone "resume" call (pauseDuration 0 returns
+// HTTP 400), so we re-activate the live schedule. We read the current workMode
+// from a fresh getAllDevices call rather than a cached value, so switching modes
+// in the app can't cause us to re-activate the wrong (stale) plan.
 LinkTapAccessory.prototype._resumeWateringPlan = function(callback) {
-  var endpoint = SCHEDULE_MODE_ENDPOINTS[this.scheduleMode] || SCHEDULE_MODE_ENDPOINTS.sevenDay;
-  var data = {
-    username: username,
-    apiKey: apiKey,
-    gatewayId: gatewayId,
-    taplinkerId: this.taplinkerId
+  var self = this;
+
+  var doResume = function(mode) {
+    var endpoint = SCHEDULE_MODE_ENDPOINTS[mode];
+    if (!endpoint) {
+      self.log.warn("%s: could not determine the active watering mode; skipping " +
+        "re-activation to avoid forcing the wrong schedule. The pause will lapse " +
+        "on its own after %s.", self.name,
+        self.pauseHours === -1 ? "the indefinite pause is cleared" : self.pauseHours + "h");
+      if (callback) callback();
+      return;
+    }
+    var data = {
+      username: username,
+      apiKey: apiKey,
+      gatewayId: gatewayId,
+      taplinkerId: self.taplinkerId
+    };
+    self.log("%s watering plan resumed (re-activating %s)", self.name, endpoint);
+    self._postLinkTap(endpoint, data, callback);
   };
-  this.log("%s watering plan resumed (re-activating %s)", this.name, endpoint);
-  this._postLinkTap(endpoint, data, callback);
+
+  if (this.platform && typeof this.platform.fetchLiveMode === 'function') {
+    this.platform.fetchLiveMode(this.taplinkerId, function(err, liveMode) {
+      if (err) {
+        self.log.warn("%s: couldn't read live mode for resume (%s); using %s",
+          self.name, err.message, self._detectedMode || self.scheduleMode);
+        doResume(self._detectedMode || self.scheduleMode);
+      } else {
+        doResume(liveMode || self._detectedMode || self.scheduleMode);
+      }
+    });
+  } else {
+    doResume(this._detectedMode || this.scheduleMode);
+  }
 };
 
 // Generic POST helper for LinkTap endpoints that just need a success/fail result
@@ -597,7 +695,7 @@ LinkTapAccessory.prototype._setDurationTimerValue = function(value, callback) {
 
 /**
  * Possible future work:
- * - Characteristic.InUse / active watering state reflected live from polling
  * - Eco mode (eco / ecoOn / ecoOff) exposed as configurable options
- * - Water volume reporting for G2/G2S flow-meter devices
+ * - Water volume reporting (vel/vol) for G2/G2S flow-meter devices
+ * - Webhook listener for push updates instead of polling (lower latency)
  **/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-linktap",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Homebridge plugin for LinkTap (https://www.link-tap.com) based on https://github.com/grover/homebridge-delayed-switches",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "homebridge-platform-linktap-v2",
-  "version": "1.9.0",
-  "description": "Fixed Homebridge plugin for LinkTap (https://www.link-tap.com) - compatible with Homebridge v2",
+  "name": "homebridge-platform-linktap",
+  "version": "0.2.0",
+  "description": "Homebridge plugin for LinkTap (https://www.link-tap.com) based on https://github.com/grover/homebridge-delayed-switches",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/phbuilds/homebridge-platform-linktap-v2.git"
+    "url": "git+https://github.com/hakt0-r/homebridge-platform-linktap.git"
   },
   "keywords": [
     "homebridge-plugin",
@@ -21,9 +21,9 @@
   "author": "hakt0-r",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/phbuilds/homebridge-platform-linktap-v2/issues"
+    "url": "https://github.com/hakt0-r/homebridge-platform-linktap/issues"
   },
-  "homepage": "https://github.com/phbuilds/homebridge-platform-linktap-v2#readme",
+  "homepage": "https://github.com/hakt0-r/homebridge-platform-linktap#readme",
   "engines": {
     "homebridge": ">=1.6.0",
     "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "homebridge-platform-linktap",
-  "version": "0.1.0",
-  "description": "Homebridge plugin for LinkTap (https://www.link-tap.com)",
+  "name": "homebridge-platform-linktap-v2",
+  "version": "1.9.1",
+  "description": "Fixed Homebridge plugin for LinkTap (https://www.link-tap.com) - compatible with Homebridge v2",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hakt0-r/homebridge-platform-linktap.git"
+    "url": "git+https://github.com/phbuilds/homebridge-platform-linktap-v2.git"
   },
   "keywords": [
     "homebridge-plugin",
@@ -21,9 +21,9 @@
   "author": "hakt0-r",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/hakt0-r/homebridge-platform-linktap/issues"
+    "url": "https://github.com/phbuilds/homebridge-platform-linktap-v2/issues"
   },
-  "homepage": "https://github.com/hakt0-r/homebridge-platform-linktap#readme",
+  "homepage": "https://github.com/phbuilds/homebridge-platform-linktap-v2#readme",
   "engines": {
     "homebridge": ">=1.6.0",
     "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-linktap",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Homebridge plugin for LinkTap (https://www.link-tap.com) based on https://github.com/grover/homebridge-delayed-switches",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-linktap-v2",
-  "version": "1.9.1",
+  "version": "1.9.0",
   "description": "Fixed Homebridge plugin for LinkTap (https://www.link-tap.com) - compatible with Homebridge v2",
   "main": "index.js",
   "scripts": {

--- a/sample-config.json
+++ b/sample-config.json
@@ -1,38 +1,20 @@
-Help...
-"platforms":[
-	{
-	    "platform": "LinkTapPlatform",
-	    "username": "",				//Required. String type. Your LinkTap account's username
-	    "apiKey": "",				//Required. String type. Your API key
-	    "gatewayId": "",				//Required. String type. Your LinkTap Gateway's first 16-digits/letters ID, case insensitive, no dash symbol
-	    "taps": [
-	        {
-	            "name": "",				//Required. LinkTap name friendly name.
-	            "location": "",			//Optional. friendly location name.
-	            "taplinkerId": "",			//Required. String type. Your LinkTap Taplinker's first 16-digits/letters ID, case insensitive, no dash symbol
-	            "duration": 1,			//Required. The watering duration (unit is minutes) 1..1439 minutes. Default 1 minute.
-		    "autoBack": true			//Required. Defaults to true
-	    	}
-		]
-	}
-]
-
-
-Use this...
-"platforms":[
-	{
-	    "platform": "LinkTapPlatform",
-	    "username": "",
-	    "apiKey": "",
-	    "gatewayId": "",
-	    "taps": [
-	        {
-	            "name": "",
-	            "location": "",
-	            "taplinkerId": "",
-	            "duration": 1,
-		    "autoBack": true
-	    	}
-		]
-	}
-]
+{
+  "platforms": [
+    {
+      "platform": "LinkTapPlatform",
+      "username": "your_linktap_username",
+      "apiKey": "your_api_key",
+      "gatewayId": "your_gateway_id",
+      "pollInterval": 5,
+      "taps": [
+        {
+          "name": "Garden Tap",
+          "location": "Back garden",
+          "taplinkerId": "your_taplinker_id",
+          "duration": 10,
+          "autoBack": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
 An update that rebuilds the plugin for modern Homebridge and turns each tap into a full-featured HomeKit irrigation accessory with live status, alerts, and flow metering — while remaining compatible with the original switch behaviour.

> [!NOTE]
> **Valve or switch — your choice.** Taps are now exposed as a HomeKit **irrigation valve** by default (`useValve: true`), which adds the Active/InUse distinction and live flow sensing. If you prefer the original behaviour, set **`useValve: false`** for a plain on/off **switch** — no need to re-add the accessory. Switching between the two modes does require re-adding the accessory once.

## Compatibility & security
- Restored compatibility with Homebridge v2 / modern HAP-nodejs (ES6 Characteristic classes; string-based characteristic props).
- Replaced the deprecated `request` dependency with Node's built-in `https`.
- Pinned dependencies and corrected the `engines` field (Node 18+, Homebridge 1.6+).
- Stopped logging the API key.

## Watering control
- **Irrigation valve model** — taps appear as HomeKit valves (Active + InUse) by default, with live flow sensing. Set `useValve: false` to keep the original on/off switch.
- **Real stop on turn-off**, with handling for the API's 15-second rate limit.
- **Adjustable duration from HomeKit** — the Duration Timer now drives watering length, with range clamping and a sensible default.

## Status & monitoring
- **Battery level + low-battery warning.**
- **Connection status** (online/offline) via StatusFault.
- **Live watering state** — reflects watering started from the app, manual button, or schedules.
- **Combined fault alert** — a single sensor that trips on water cut, clog, valve failure, fallen device, abnormal flow, and (defensively) freeze.
- **Water volume** — per-cycle litres for G2/G2S flow-meter models, shown in Eve / Controller for HomeKit (ignored harmlessly by the stock Home app).

## Schedules
- **Pause/resume schedule switch** — pauses scheduled watering for a configurable duration; resume re-activates the watering plan that is live at the moment of resume, so changing modes in the app never restores the wrong schedule.
- **Automatic mode detection** using the official LinkTap workMode codes (7-Day, Interval, Odd-Even, Month, Calendar).

## Configuration
- New optional fields: `pollInterval`, `useValve`, `pauseHours`, and `scheduleMode`.
- Includes `config.schema.json` for full configuration via the Homebridge UI.

## Important considerations
- **Status latency** — battery, signal, watering, alerts, and volume refresh on the poll interval (5 min minimum, plus up to ~1 min cloud-side).
- **Known limitation** — pause state and app-side mode changes aren't reflected back in HomeKit, as the device status response contains no pause-state field.

---

> Forked from [hakt0-r/homebridge-platform-linktap](https://github.com/hakt0-r/homebridge-platform-linktap), rebuilt for Homebridge v2 with the features above.