### PR TITLE
v1.2.1— Configurable status logging and polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Each tap appears in HomeKit as an irrigation valve (or a plain switch if preferr
 - Water volume per cycle for G2/G2S flow-meter models (visible in Eve / Controller for HomeKit)
 - Pause and resume scheduled watering plans, with automatic detection of the active mode
 - Choice of accessory type: irrigation valve (default) or legacy on/off switch
+- Configurable poll interval and optional quiet logging
 
 ## Installation
 
@@ -35,6 +36,7 @@ Add the following to the `platforms` section of your Homebridge `config.json`, o
   "apiKey": "your_api_key",
   "gatewayId": "your_gateway_id",
   "pollInterval": 5,
+  "verboseStatusLog": true,
   "taps": [
     {
       "name": "Garden Tap",
@@ -58,6 +60,7 @@ Add the following to the `platforms` section of your Homebridge `config.json`, o
 | `apiKey` | Yes | Your API key from https://www.link-tap.com/#!/api-for-developers |
 | `gatewayId` | Yes | Your gateway's first 16-digit ID (no dashes) |
 | `pollInterval` | No | Status refresh in minutes. Minimum 5 (API limit). 0 disables polling. Default 5 |
+| `verboseStatusLog` | No | Show the routine per-poll status line in the main log. Set false to send it to the debug log only. Default true |
 
 ### Tap fields
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Add the following to the `platforms` section of your Homebridge `config.json`, o
   "username": "your_linktap_username",
   "apiKey": "your_api_key",
   "gatewayId": "your_gateway_id",
-  "pollInterval": 5,
-  "verboseStatusLog": true,
+  "pollInterval": 15,
+  "verboseStatusLog": false,
   "taps": [
     {
       "name": "Garden Tap",
@@ -59,8 +59,8 @@ Add the following to the `platforms` section of your Homebridge `config.json`, o
 | `username` | Yes | Your LinkTap account username |
 | `apiKey` | Yes | Your API key from https://www.link-tap.com/#!/api-for-developers |
 | `gatewayId` | Yes | Your gateway's first 16-digit ID (no dashes) |
-| `pollInterval` | No | Status refresh in minutes. Minimum 5 (API limit). 0 disables polling. Default 5 |
-| `verboseStatusLog` | No | Show the routine per-poll status line in the main log. Set false to send it to the debug log only. Default true |
+| `pollInterval` | No | Status refresh in minutes. Minimum 5 (API limit). 0 disables polling. Default 15 |
+| `verboseStatusLog` | No | Show the routine per-poll status line in the main log. Default false (debug log only); set true to show it in the main log |
 
 ### Tap fields
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -33,6 +33,13 @@
         "minimum": 0,
         "description": "How often to refresh battery and signal status. Minimum 5 (LinkTap API limit). Set to 0 to disable status polling."
       },
+      "verboseStatusLog": {
+        "title": "Show status updates in the main log",
+        "type": "boolean",
+        "required": false,
+        "default": true,
+        "description": "When on, each status poll prints a battery/signal/state line to the main log. Turn off to send these to the debug log only (keeps the main log quiet). Watering, online/offline, and alert changes are always logged regardless of this setting."
+      },
       "taps": {
         "title": "Taps",
         "type": "array",

--- a/config.schema.json
+++ b/config.schema.json
@@ -29,16 +29,16 @@
         "title": "Status Poll Interval (minutes)",
         "type": "integer",
         "required": false,
-        "default": 5,
+        "default": 15,
         "minimum": 0,
-        "description": "How often to refresh battery and signal status. Minimum 5 (LinkTap API limit). Set to 0 to disable status polling."
+        "description": "How often to refresh battery and signal status. Minimum 5 (LinkTap API limit). Set to 0 to disable status polling. Higher values reduce network traffic."
       },
       "verboseStatusLog": {
         "title": "Show status updates in the main log",
         "type": "boolean",
         "required": false,
-        "default": true,
-        "description": "When on, each status poll prints a battery/signal/state line to the main log. Turn off to send these to the debug log only (keeps the main log quiet). Watering, online/offline, and alert changes are always logged regardless of this setting."
+        "default": false,
+        "description": "When on, each status poll prints a battery/signal/state line to the main log. Off by default, sending these to the debug log only (keeps the main log quiet). Watering, online/offline, and alert changes are always logged regardless of this setting."
       },
       "taps": {
         "title": "Taps",

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const https = require('https');
 const _baseURL = 'https://www.link-tap.com/api/';
 const RATE_LIMIT_MS = 15000;        // activateInstantMode: min 15s between calls
 const MIN_POLL_MINUTES = 5;         // getAllDevices: manufacturer limits status polling to every 5 min
-const DEFAULT_POLL_MINUTES = 5;
+const DEFAULT_POLL_MINUTES = 15;    // default refresh; raise/lower via pollInterval. 5 = API minimum
 const LOW_BATTERY_THRESHOLD = 20;   // percent at or below which HomeKit shows a low-battery warning
 var Service, Characteristic;
 var debug = require('debug')('linktap');
@@ -69,7 +69,7 @@ function LinkTapPlatform(log, config, api) {
     return;
   }
   this.config = config;
-  this.verboseStatusLog = config.verboseStatusLog !== false; // status in main logs by default; set false for debug-only
+  this.verboseStatusLog = config.verboseStatusLog === true; // debug-only by default; set true to show status in the main log
 
   this.api = api;
 

--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ function LinkTapPlatform(log, config, api) {
     return;
   }
   this.config = config;
+  this.verboseStatusLog = config.verboseStatusLog !== false; // status in main logs by default; set false for debug-only
 
   this.api = api;
 
@@ -434,6 +435,9 @@ LinkTapAccessory.prototype.updateStatus = function(batteryPct, signalPct, online
   }
 
   if (online !== null && online !== undefined) {
+    if (online !== this._online) {
+      this.log("%s is now %s", this.name, online ? "online" : "offline");
+    }
     this._online = online;
     if (this._service) {
       this._service.updateCharacteristic(Characteristic.StatusFault, online ? 0 : 1);
@@ -446,6 +450,7 @@ LinkTapAccessory.prototype.updateStatus = function(batteryPct, signalPct, online
   if (watering !== null && watering !== undefined) {
     var newInUse = watering ? 1 : 0;
     if (newInUse !== this._inUse) {
+      this.log("%s %s", this.name, watering ? "started watering" : "stopped watering");
       this._inUse = newInUse;
       this._active = newInUse;
       this._reflectWateringState();
@@ -485,7 +490,12 @@ LinkTapAccessory.prototype.updateStatus = function(batteryPct, signalPct, online
     }
   }
 
-  this.log("%s status: battery %s%%, signal %s%%, %s%s%s",
+  // Routine per-poll status summary. Goes to the main log by default; set
+  // verboseStatusLog: false to send it to debug only and keep the log quiet.
+  // Meaningful changes (online/offline, watering start/stop, faults) always log
+  // at normal level above, regardless of this setting.
+  var statusLog = (this.platform && this.platform.verboseStatusLog) ? this.log.bind(this) : debug;
+  statusLog("%s status: battery %s%%, signal %s%%, %s%s%s",
     this.name, this._batteryLevel, this._signal,
     this._online ? "online" : "offline",
     (watering !== undefined ? (watering ? ", watering" : ", idle") : ""),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-linktap",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Homebridge plugin for LinkTap (https://www.link-tap.com) based on https://github.com/grover/homebridge-delayed-switches",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-linktap",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Homebridge plugin for LinkTap (https://www.link-tap.com) based on https://github.com/grover/homebridge-delayed-switches",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Add user-configurable logging and polling controls with quieter defaults.

- New `verboseStatusLog` option (default false): routine per-poll status goes to the debug log only, keeping the main log quiet. Set true to show it in the main log.
- `pollInterval` controls how often status refreshes (default 15 minutes; minimum 5, the API limit; 0 disables polling)
- Watering start/stop, online/offline, and fault changes always log at normal level regardless of the status-log setting.
- Both options are exposed in config.schema.json for the Homebridge UI.